### PR TITLE
[SKOOP-205] 'Project name' in the notifications 'Project membership requires approval'

### DIFF
--- a/src/app/my-messages/approve-project-message-card/approve-project-message-card.component.html
+++ b/src/app/my-messages/approve-project-message-card/approve-project-message-card.component.html
@@ -10,7 +10,7 @@
     </div>
     <div fxLayout="row">
       <div class="messages-description-label">Message:</div>
-      <div class="messages-message-text">You need to approve project memberships of <a
+      <div class="messages-message-text">You need to approve the project membership in <strong>{{notification.userProject.project.name}}</strong> of <a
         routerLink="/my-subordinates/{{notification.userProject.user.id}}/project-memberships">{{notification.userProject.user.firstName}} {{notification.userProject.user.lastName}}</a>
       </div>
     </div>


### PR DESCRIPTION
Displaying 'Project name' in the notifications 'Project membership requires approval'
@LebedkoDmitry could you please take a look?