### PR TITLE
feature/SKOOP-220

### DIFF
--- a/src/docker/httpd.conf
+++ b/src/docker/httpd.conf
@@ -570,3 +570,5 @@ SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 </IfModule>
 
+Header onsuccess unset X-Frame-Options
+Header always set X-Frame-Options "sameorigin"


### PR DESCRIPTION
Apache configuration file was changed to always set the header `X-Frame-Options` to `sameorigin` to prevent clickjacking attacks.
@georgwittberger @svetivanova could you please take a look?